### PR TITLE
Update requirements.md

### DIFF
--- a/sections/requirements.md
+++ b/sections/requirements.md
@@ -2,7 +2,7 @@
 
 Before using `smart-exchange` you need to install the following tools and you need to make sure that **ALL** of them are available in your PATH
 
-- [node](https://nodejs.org/)
+- [node](https://nodejs.org/) *>= 0.11.12*
 - [npm](https://www.npmjs.com/)
 - [solc](https://github.com/ethereum/cpp-ethereum) *0.1.0, available as a part of cpp-ethereum --devel*
 - [go-etheruem](https://github.com/ethereum/go-ethereum) *0.9.38*


### PR DESCRIPTION
child_process#execSync wasn't added until node 0.11.12 https://github.com/joyent/node/releases/v0.11.12

some linux distributions still use 0.10.x in the default package
